### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ android {
 
 }
 dependencies{
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }


### PR DESCRIPTION
compile, provided and apk in gradle dependencies prefix command are in gradle version 7.1.2 deprecated. Use implementation or api instead of compile, compileOnly instead of provided, and runtimeOnly instead of apk

Please update the gradle version of your package with corresponding Flutter version 3.3.2

I am using Flutter version 3.3.2, I got an error because of that, thanks